### PR TITLE
Update to RELEASE.2017-09-29T19-16-56Z

### DIFF
--- a/.final_builds/jobs/minio-server/index.yml
+++ b/.final_builds/jobs/minio-server/index.yml
@@ -19,6 +19,10 @@ builds:
     version: e20d6140c4f7fe11725bb84e9f0316bd3bdcc9c4
     blobstore_id: 62968d98-32dd-48f4-a2a5-0c462da1afcb
     sha1: fbbb0001120e63fb144c8f37b487b3e7531bbd9a
+  e9574614164741d125dca66c28b4a5d5a9478b35:
+    version: e9574614164741d125dca66c28b4a5d5a9478b35
+    blobstore_id: d4c97d6b-7805-48f4-7d1c-9ac9e9bf7d33
+    sha1: 43bc1e07a24729eec7491611ebe655ffd9b837d5
   fbf817ef1a0f9e613d0a0aa7bbf16e04416af00a:
     version: fbf817ef1a0f9e613d0a0aa7bbf16e04416af00a
     blobstore_id: 066ee81a-2315-47fd-bfb9-dea45c1f9e98

--- a/.final_builds/packages/minio/index.yml
+++ b/.final_builds/packages/minio/index.yml
@@ -1,0 +1,6 @@
+builds:
+  7c66b7dcd03e41886580074fd10fd1df9149465a:
+    version: 7c66b7dcd03e41886580074fd10fd1df9149465a
+    blobstore_id: 1a4ec70a-94cf-4996-629c-2a16c36e8c5c
+    sha1: 7c5cb1151fb53ec1594878b900bee80191f298dc
+format-version: "2"

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,8 +2,6 @@ This file contains information for maintainers.
 
 ## How to update this release with a newer version of Minio using Bosh V2
 
-In this section, the `bosh-cli` command is bound to Bosh V2 binary.
-
 ### Fetch and verify new binary
 
 The latest version of the Minio binary for amd64 Linux is available at
@@ -13,340 +11,42 @@ Download it locally and verify the shasum. Rename the binary file to
 just `minio`. Example commands:
 
 ``` shell
-MINIO_BIN_NAME=minio.RELEASE.2017-03-16T21-50-32Z
 # For a current release:
-wget -O /tmp/minio https://dl.minio.io/server/minio/release/linux-amd64/${MINIO_BIN_NAME}
-# OR, if adding an older release, the URL differs slightly:
-wget -O /tmp/minio https://dl.minio.io/server/minio/release/linux-amd64/archive/${MINIO_BIN_NAME}
+wget -O /tmp/minio https://dl.minio.io/server/minio/release/linux-amd64/minio
 
 # Then verify the sha256sum, like below (e.g. commands and output are below):
 $ sha256sum /tmp/minio
-f85839e391ec616e2a0d28740dba1d3f662f624cc13c3683a6cad8cd019ba17d  /tmp/minio
-$ curl https://dl.minio.io/server/minio/release/linux-amd64/${MINIO_BIN_NAME}.sha256sum
-f85839e391ec616e2a0d28740dba1d3f662f624cc13c3683a6cad8cd019ba17d minio.RELEASE.2017-03-16T21-50-32Z
+b7707b11c64e04be87b4cf723cca5e776b7ed3737c0d6b16b8a3d72c8b183135  /tmp/minio
+$ curl https://dl.minio.io/server/minio/release/linux-amd64/minio.sha256sum
+b7707b11c64e04be87b4cf723cca5e776b7ed3737c0d6b16b8a3d72c8b183135 minio.RELEASE.2017-09-29T19-16-56Z
 ```
-
-Though the local file is named `/tmp/minio`, we will use the full name
-(`$MINIO_BIN_NAME`) as the name of the package in the BOSH release.
-
-### Create new package
-
-``` shell
-$ bosh-cli generate-package ${MINIO_BIN_NAME}
-
-$ tree packages/${MINIO_BIN_NAME}/
-packages/minio.RELEASE.2017-03-16T21-50-32Z/
-├── packaging
-└── spec
-
-0 directories, 2 files
-
-```
-
-### Update `packaging` and `spec` files in the generated package directory
-
-The main content for these two files may be taken from the existing
-(older released) package directory.
-
-Then just replace the name of the package with the correct RELEASE
-name string used in the `packaging` script and in the `spec` files
-(e.g. minio.RELEASE.2017-03-16T21-50-32Z).
-
-After editing the files makes sure to remove any files ending in `~`
-or any other editor created backup files.
 
 ### Update blob for new package
 
 ``` shell
-bosh-cli add-blob /tmp/minio ${MINIO_BIN_NAME}/minio
+bosh2 add-blob /tmp/minio minio
 ```
 
-### Update `minio-server` job
-
-In the job directory, update the dependencies listed in the
-`jobs/minio-server/spec` file, similar to:
+Create the final release and upload blobs. Example commands:
 
 ``` shell
-packages:
-  - minio.RELEASE.2017-03-16T21-50-32Z
-
+bosh2 create-release --version=2017-09-29T19-16-56Z --final --force
+bosh2 upload-blobs # This requires you to configure s3 creds in config/private.yml
 ```
 
-Also, in the template script `jobs/minio-server/templates/ctl.erb` update the
-BINPATH variable with the new version name of the minio package. Example:
-
-``` shell
-BINPATH=/var/vcap/packages/minio.RELEASE.2017-03-16T21-50-32Z
-
+Commit the files generated to Git:
 ```
-
-### Remove old package(s) and remove reference to older blobs
-
-We remove old package directory as it is not needed for the new release.
-
-``` shell
-# Run for each older package in the packages dir (there will be usually be just one)
-git rm -f packages/minio.RELEASE.xxxxxxx
-
-# Run for each older blob referenced in config/blobs.yml:
-bosh-cli remove-blob minio.RELEASE.2017-03-16T21-50-32Z/minio
-```
-
-
-### Try it out
-
-#### Setting up bosh-lite with boshv2
-
-https://bosh.io/docs/bosh-lite
-
-Follow install steps to get the Bosh director running locally on
-VirtualBox.
-
-After performing those steps also run:
-
-``` shell
-sudo route add -net 10.244.0.0/16 gw 192.168.50.6
-```
-
-to be able to ssh/access Minio inside the VM.
-
-#### Trying/Testing release
-
-Commit changes to git before testing the candidate release:
-
-``` shell
-git commit -a -m 'Add files for new release'
-
-# Create release
-bosh-cli create-release --force
-
-# Upload above created release to VM:
-bosh-cli -e vbox upload-release # upload release
-
-# Upload stem-cell step:
-bosh-cli -e vbox upload-stemcell \
-    https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent?v=3421.9 \
-    --sha1 1396d7877204e630b9e77ae680f492d26607461d
-
-# Deploy to VM step:
-bosh-cli -e vbox --deployment minio-singlenode-deploy deploy manifests/manifest-fs.yml
-
-```
-
-Now, we can attempt to access the instance via mc:
-
-``` shell
-mc config host add b-miniofs http://10.244.0.2:9001 minio minio123
-mc mb b-miniofs/newbucket
-```
-
-If the second command above worked, we have accessed the deployed
-Minio instance. Carry out any further tests to be sure the server is
-working as expected.
-
-If everything is working as expected, upload blobs for final release
-and commit:
-
-``` shell
-bosh-cli upload-blobs # This requires you to configure s3 creds in config/private.yml
-git commit -a -m 'Add blobs'
-```
-
-And create the final release, and commit files it generates. Example
-commands:
-
-``` shell
-bosh-cli create-release --final
-
-git add .final_builds/jobs/minio-server/index.yml
+git add config/blobs.yml
 git add releases/minio/index.yml
-git add .final_builds/packages/minio.RELEASE.2017-06-13T19-01-01Z/
-git releases/minio/minio-4.yml
-git commit -m 'Publish release minio.RELEASE.2017-06-13T19-01-01Z'
+git add releases/minio/minio-2017-09-29T19-16-56Z.yml
+git commit -m 'Minio BOSH release 2017-09-29T19-16-56Z'
 ```
 
-All done!
+All done, send a PR!
 
-## How to sanity check a BOSH release
+Create a Github TAG `RELEASE.2017-09-29T19-16-56Z`
+Create a Github Release here https://github.com/minio/minio-boshrelease/releases
 
-The aim here is to try and create a release tarball like how a user
-may do. This is done by starting from a vanilla ubuntu docker image,
-and installing each required component:
+After a while new bosh release should automatically appear here:
+https://bosh.io/releases/github.com/minio/minio-boshrelease
 
-1. Create a Dockerfile with (both) bosh cli's installed:
-
-``` dockerfile
-FROM ubuntu
-
-RUN apt update && \
-    apt-get install -y build-essential ruby ruby-dev libxml2-dev \
-    libsqlite3-dev libxslt1-dev libpq-dev libmysqlclient-dev zlib1g-dev git wget
-
-RUN gem install bosh_cli --no-ri --no-rdoc
-
-RUN wget -q -O /usr/local/bin/bosh2 \
-    https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-2.0.28-linux-amd64
-
-RUN chmod +x /usr/local/bin/bosh2
-
-```
-2. Build docker image, launch container by running a shell, and clone
-   the release:
-
-``` shell
-docker build -t donatello/minio-bosh-test .
-docker run --rm -it donatello/minio-bosh-test /bin/bash
-# Inside the container:
-git clone https://github.com/minio/minio-boshrelease.git
-cd minio-boshrelease
-```
-
-3. Try making a tarball from the release:
-
-``` shell
-# Replace '3' with whatever is the latest below
-bosh create release releases/minio/minio-3.yml --with-tarball
-# or with bosh v2:
-bosh2 create-release --tarball=/tmp/release.tgz releases/minio/minio-3.yml
-```
-
-In either case, the command should work and a tarball should be created.
-
-## OLDER INFO: How to update this release with a newer version of Minio with Bosh V1 (DEPRECATED)
-
-The latest version of the Minio binary for amd64 Linux is available at
-https://dl.minio.io/server/minio/release/linux-amd64/
-
-Download it locally and verify the shasum. Rename the binary file to
-just `minio`. Example commands:
-
-``` shell
-MINIO_BIN_NAME=minio.RELEASE.2017-03-16T21-50-32Z
-# For a current release:
-wget -O /tmp/minio https://dl.minio.io/server/minio/release/linux-amd64/${MINIO_BIN_NAME}
-# OR, if adding an older release, the URL differs slightly:
-wget -O /tmp/minio https://dl.minio.io/server/minio/release/linux-amd64/archive/${MINIO_BIN_NAME}
-
-# Then verify the sha256sum, like below (e.g. commands and output are below):
-$ sha256sum /tmp/minio
-f85839e391ec616e2a0d28740dba1d3f662f624cc13c3683a6cad8cd019ba17d  /tmp/minio
-$ curl https://dl.minio.io/server/minio/release/linux-amd64/${MINIO_BIN_NAME}.sha256sum
-f85839e391ec616e2a0d28740dba1d3f662f624cc13c3683a6cad8cd019ba17d minio.RELEASE.2017-03-16T21-50-32Z
-```
-
-Though the local file is named `/tmp/minio`, we will use the full name
-(`$MINIO_BIN_NAME`) as the name of the package in the BOSH release.
-
-### Create new package
-
-``` shell
-$ bosh generate package ${MINIO_BIN_NAME}
-
-$ tree packages/${MINIO_BIN_NAME}/
-packages/minio.RELEASE.2017-03-16T21-50-32Z/
-├── packaging
-├── pre_packaging
-└── spec
-
-0 directories, 3 files
-
-```
-
-### Update `packaging` and `spec` files in the generated package directory
-
-The main content for these two files may be taken from the existing
-(released) package directory.
-
-Then just replace the name of the package with the correct RELEASE
-name string used in the `packaging` script and in the `spec` files
-(e.g. minio.RELEASE.2017-03-16T21-50-32Z).
-
-After editing the files makes sure to remove any files ending in `~`
-or any other editor created backup files.
-
-### Update blob for new package
-
-``` shell
-bosh add blob /tmp/minio ${MINIO_BIN_NAME}
-```
-
-### Update `minio-server` job
-
-In the job directory, update the dependencies listed in the
-`jobs/minio-server/spec` file, similar to:
-
-``` shell
-packages:
-  - minio.RELEASE.2017-03-16T21-50-32Z
-
-```
-
-Also, in the template script `jobs/minio-server/templates/ctl.erb` update the
-BINPATH variable with the new version name of the minio package. Example:
-
-``` shell
-BINPATH=/var/vcap/packages/minio.RELEASE.2017-03-16T21-50-32Z
-
-```
-
-### Remove old package(s)
-
-We remove old package directory as it is not needed for the new release.
-
-``` shell
-# Run for each older package in the packages dir (there will be usually be just one)
-git rm -f packages/minio.RELEASE.xxxxxxx
-```
-
-### Try it out
-
-Commit changes to git before testing the candidate release:
-
-``` shell
-git commit -a -m 'Add files for new release'
-bosh create release --force
-bosh upload release # also upload stemcell if needed
-bosh deployment manifests/manifest-fs.yml # Set manifest
-bosh deploy
-```
-
-To test if the deployment worked - we need to connect to the deployed
-Minio instance inside the bosh-lite Vagrant VM. Run the following
-script from the bosh-lite repo directory to enable network access:
-
-``` shell
-bin/add-route
-```
-
-It will ask for sudo permission to add a network route.
-
-Now, we can attempt to access the instance via mc:
-
-``` shell
-mc config host add b-miniofs http://10.244.0.2:9001 minio minio123
-mc mb b-miniofs/newbucket
-```
-
-If the second command above worked, we have accessed the deployed
-Minio instance. Carry out any further tests to be sure the server is
-working as expected.
-
-If everything is working as expected, upload blobs for final release
-and commit:
-
-``` shell
-bosh upload blobs # This requires you to configure s3 creds in config/private.yml
-git commit -a -m 'Add blobs'
-```
-
-And create the final release, and commit files it generates. Example
-commands:
-
-``` shell
-bosh create release --final
-git add .final_builds/jobs/minio-server/index.yml
-git add releases/minio/index.yml
-git add .final_builds/packages/minio.RELEASE.2017-06-13T19-01-01Z/
-git releases/minio/minio-4.yml
-git commit -m 'Publish release minio.RELEASE.2017-06-13T19-01-01Z'
-```

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,4 @@
-minio.RELEASE.2017-08-05T00-00-53Z/minio:
-  size: 20796928
-  object_id: 753d1638-e2e3-4ed6-6250-c7d0a9f03b75
-  sha: 875320b0bb6b60cbef80c475a1f1c950dbba2aad
+minio:
+  size: 21640704
+  object_id: 99f79021-ff8c-4e00-6d9b-70b98a0dbc84
+  sha: eeea7584cc16ae13c1231a98bdca5c01e2acb348

--- a/config/final.yml
+++ b/config/final.yml
@@ -2,6 +2,8 @@
 blobstore:
   provider: s3
   options:
-    bucket_name: minio-boshreleases
-    region: us-east-1
+    bucket_name: minio-bosh-blobs
+    host: pivotal.minio.io
+    port: 9000
+
 final_name: minio

--- a/jobs/minio-server/spec
+++ b/jobs/minio-server/spec
@@ -5,7 +5,7 @@ templates:
   config.json.erb: config/config.json
 
 packages:
-- minio.RELEASE.2017-08-05T00-00-53Z
+- minio
 
 consumes:
 - name: minio-server

--- a/jobs/minio-server/templates/ctl.erb
+++ b/jobs/minio-server/templates/ctl.erb
@@ -6,7 +6,7 @@ CONFIG_DIR=/var/vcap/jobs/minio-server/config
 STORE_DIR=/var/vcap/store/minio-server
 PIDFILE=${RUN_DIR}/pid
 # If minio package is updated, this line needs to be updated as well.
-BINPATH=/var/vcap/packages/minio.RELEASE.2017-08-05T00-00-53Z
+BINPATH=/var/vcap/packages/minio
 
 mkdir -p ${RUN_DIR} ${LOG_DIR} ${CONFIG_DIR} ${STORE_DIR}
 chown -R vcap:vcap $RUN_DIR $LOG_DIR $CONFIG_DIR ${STORE_DIR}

--- a/packages/minio.RELEASE.2017-08-05T00-00-53Z/packaging
+++ b/packages/minio.RELEASE.2017-08-05T00-00-53Z/packaging
@@ -1,4 +1,0 @@
-set -e
-
-cp -a minio.RELEASE.2017-08-05T00-00-53Z/minio ${BOSH_INSTALL_TARGET}
-chmod +x ${BOSH_INSTALL_TARGET}/minio

--- a/packages/minio.RELEASE.2017-08-05T00-00-53Z/spec
+++ b/packages/minio.RELEASE.2017-08-05T00-00-53Z/spec
@@ -1,7 +1,0 @@
----
-name: minio.RELEASE.2017-08-05T00-00-53Z
-
-dependencies: []
-
-files:
-- minio.RELEASE.2017-08-05T00-00-53Z/minio # From https://dl.minio.io/server/minio/release/linux-amd64/

--- a/packages/minio/packaging
+++ b/packages/minio/packaging
@@ -1,0 +1,4 @@
+set -e
+
+cp -a minio ${BOSH_INSTALL_TARGET}
+chmod +x ${BOSH_INSTALL_TARGET}/minio

--- a/packages/minio/spec
+++ b/packages/minio/spec
@@ -1,0 +1,7 @@
+---
+name: minio
+
+dependencies: []
+
+files:
+- minio # From https://dl.minio.io/server/minio/release/linux-amd64/

--- a/releases/minio/index.yml
+++ b/releases/minio/index.yml
@@ -1,6 +1,8 @@
 builds:
   25bf0482-9baf-423b-a1c7-cbb9efe29295:
     version: "5"
+  512f44ef-7c99-43a5-590d-eba0a0134045:
+    version: 2017-09-29T19-16-56Z
   5b62fd85-0eee-4810-8470-e2b87b7ecffe:
     version: "2"
   689f402a-4df6-4eca-bd5c-f5af678d1961:

--- a/releases/minio/minio-2017-09-29T19-16-56Z.yml
+++ b/releases/minio/minio-2017-09-29T19-16-56Z.yml
@@ -1,0 +1,19 @@
+name: minio
+version: 2017-09-29T19-16-56Z
+commit_hash: 3c0ed3c
+uncommitted_changes: true
+jobs:
+- name: minio-server
+  version: e9574614164741d125dca66c28b4a5d5a9478b35
+  fingerprint: e9574614164741d125dca66c28b4a5d5a9478b35
+  sha1: 43bc1e07a24729eec7491611ebe655ffd9b837d5
+packages:
+- name: minio
+  version: 7c66b7dcd03e41886580074fd10fd1df9149465a
+  fingerprint: 7c66b7dcd03e41886580074fd10fd1df9149465a
+  sha1: 7c5cb1151fb53ec1594878b900bee80191f298dc
+  dependencies: []
+license:
+  version: e6c4ccc65c76e75e2338d1edabdcf264d37ee663
+  fingerprint: e6c4ccc65c76e75e2338d1edabdcf264d37ee663
+  sha1: b2ab9dce5cbd539d92c8c402492a0470a89897a7


### PR DESCRIPTION
Simplified packaging/jobs files. This makes the process of creating bosh release much simpler. Hence made the changes to MAINTAINERS.md as well.

Changed the versioning to follow minio versioning style, i.e now the version will appear as `2017-09-29T19-16-56Z` in  http://bosh.io/releases/github.com/minio/minio-boshrelease?all=1

We now use https://pivotal.minio.io:9000/minio-bosh-blobs to host the blobs instead of AWS S3

The steps mentioned in MAINTAINERS.md can be scripted. So we should just be able to do
./update.sh
and push the commit to Github and send a PR. Will implement update.sh by the time we release next minio version