### PR TITLE
Update manifest-fs-example for port property

### DIFF
--- a/manifests/manfest-fs-example.yaml
+++ b/manifests/manfest-fs-example.yaml
@@ -24,7 +24,7 @@ instance_groups:
       credential:
         accesskey: minio
         secretkey: minio123
-        port: 9000
+      port: 9000
   networks:
   - name: default
   vm_type: default


### PR DESCRIPTION
The port property in the job spec is not nested under `credential`:
https://github.com/minio/minio-boshrelease/blob/master/jobs/minio-server/spec#L31