### PR TITLE
Remove director_uuid from manifest-fs-example

### DIFF
--- a/manifests/manfest-fs-example.yaml
+++ b/manifests/manfest-fs-example.yaml
@@ -1,6 +1,5 @@
 ---
 name: minio
-director_uuid: UUID
 
 releases:
 - name: minio


### PR DESCRIPTION
`director_uuid` not required by bosh cli v2.
https://bosh.io/docs/manifest-v2.html#deployment