### PR TITLE
Fix max-in-flight

### DIFF
--- a/manifests/manifest-fs-example.yml
+++ b/manifests/manifest-fs-example.yml
@@ -34,5 +34,5 @@ update:
   canaries: 1
   canary_watch_time: 1000-30000
   update_watch_time: 1000-30000
-  max_in_flight: 10
+  max_in_flight: 1
 


### PR DESCRIPTION
Unless you want your minio cluster to become unavailable, you will want to set this to 1.