### PR TITLE
Fix typo that broke nas support

### DIFF
--- a/jobs/minio-nas/templates/ctl.erb
+++ b/jobs/minio-nas/templates/ctl.erb
@@ -2,8 +2,8 @@
 
 RUN_DIR=/var/vcap/sys/run/minio-nas
 LOG_DIR=/var/vcap/sys/log/minio-nas
-DATA_DIR='<%= p("data_dir") %>)'
-CONFIG_DIR='<%= p("config_dir") %>)'
+DATA_DIR='<%= p("data_dir") %>'
+CONFIG_DIR='<%= p("config_dir") %>'
 PIDFILE=${RUN_DIR}/pid
 BINPATH=/var/vcap/packages/minio
 


### PR DESCRIPTION
It appears when https://github.com/minio/minio-boshrelease/pull/61 was merged it added extra `)` to the values.  This PR removes those extra `)`.