### PR TITLE
fix config.json sync up issue

### DIFF
--- a/jobs/minio-server/templates/ctl.erb
+++ b/jobs/minio-server/templates/ctl.erb
@@ -12,7 +12,7 @@ BINPATH=/var/vcap/packages/minio
 mkdir -p ${RUN_DIR} ${LOG_DIR} ${CONFIG_DIR} ${DATA_DIR}
 chown -R vcap:vcap $RUN_DIR $LOG_DIR $CONFIG_DIR ${DATA_DIR}
 
-if [ ! -f ${CONFIG_DIR}/config.json ]; then
+if [ ! -f ${CONFIG_DIR}/config.json ] || [ /var/vcap/jobs/minio-server/config/config.json -nt ${CONFIG_DIR}/config.json ]; then
     cp /var/vcap/jobs/minio-server/config/config.json ${CONFIG_DIR}/config.json
 fi
 


### PR DESCRIPTION
## Issue

If we're trying to change the `accesskey` and/or `secretkey` by redeploying the BOSH deployment like `bosh deploy -d minio ...`, after completion of the deployment,  we can't login as expected by using the new keys as the change hasn't properly been picked up -- In this case, we actually can use the old keys to login.

## The Fix in this PR

This is because the logic in `ctl.erb` is not correct.

```
if [ ! -f ${CONFIG_DIR}/config.json ]; then
    cp /var/vcap/jobs/minio-server/config/config.json ${CONFIG_DIR}/config.json
fi
```
Which means that if the file already exists, it will simply skip the sync up.

So the fix becomes straightforward:

```
if [ ! -f ${CONFIG_DIR}/config.json ] || [ /var/vcap/jobs/minio-server/config/config.json -nt ${CONFIG_DIR}/config.json ]; then
    cp /var/vcap/jobs/minio-server/config/config.json ${CONFIG_DIR}/config.json
fi
```