### PR TITLE
Fix escaping in ERB scripts or JSON files

### DIFF
--- a/jobs/mc/templates/run.erb
+++ b/jobs/mc/templates/run.erb
@@ -1,11 +1,19 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 export PATH=$PATH:/var/vcap/packages/mc
 
-ACCESS_KEY="<%= link('minio').p('credential.accesskey') %>"
-SECRET_KEY="<%= link('minio').p('credential.secretkey') %>"
-PORT="<%= link('minio').p('port') %>"
-HOST="<%= link('minio').instances[0].address %>"
+ACCESS_KEY=<%= esc(link('minio').p('credential.accesskey')) %>
+SECRET_KEY=<%= esc(link('minio').p('credential.secretkey')) %>
+PORT=<%= esc(link('minio').p('port')) %>
+HOST=<%= esc(link('minio').instances[0].address) %>
+
 export MC_HOSTS_myminio=http://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
 
 bash <<EOF

--- a/jobs/minio-azure/templates/ctl.erb
+++ b/jobs/minio-azure/templates/ctl.erb
@@ -1,4 +1,11 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 RUN_DIR=/var/vcap/sys/run/minio-azure
 LOG_DIR=/var/vcap/sys/log/minio-azure
@@ -10,15 +17,15 @@ BINPATH=/var/vcap/packages/minio
 mkdir -p ${RUN_DIR} ${LOG_DIR} ${CONFIG_DIR} ${STORE_DIR}
 chown -R vcap:vcap $RUN_DIR $LOG_DIR $CONFIG_DIR ${STORE_DIR}
 
-export MINIO_ACCESS_KEY="<%= p("credential.accesskey") %>"
-export MINIO_SECRET_KEY="<%= p("credential.secretkey") %>"
-export MINIO_PCF_TILE_VERSION=<%= p("pcf_tile_version") %>
+export MINIO_ACCESS_KEY=<%= esc(p("credential.accesskey")) %>
+export MINIO_SECRET_KEY=<%= esc(p("credential.secretkey")) %>
+export MINIO_PCF_TILE_VERSION=<%= esc(p("pcf_tile_version")) %>
 
 case $1 in
 
   start)
     echo $$ > $PIDFILE
-    exec ${BINPATH}/minio gateway --address ':<%= p("port") %>' azure \
+    exec ${BINPATH}/minio gateway --address :<%= esc(p("port")) %> azure \
          >> ${LOG_DIR}/minio-server.stdout.log \
          2>> ${LOG_DIR}/minio-server.stderr.log
     ;;

--- a/jobs/minio-azure/templates/health_check.erb
+++ b/jobs/minio-azure/templates/health_check.erb
@@ -13,7 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+<%
+  require "shellwords"
 
-http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= p("port") %>/minio/health/live)
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
+
+http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= esc(p("port")) %>/minio/health/live)
 
 [ "$http_response" = "200" ]

--- a/jobs/minio-gcs/templates/ctl.erb
+++ b/jobs/minio-gcs/templates/ctl.erb
@@ -1,4 +1,11 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 RUN_DIR=/var/vcap/sys/run/minio-gcs
 LOG_DIR=/var/vcap/sys/log/minio-gcs
@@ -10,17 +17,17 @@ BINPATH=/var/vcap/packages/minio
 mkdir -p ${RUN_DIR} ${LOG_DIR} ${CONFIG_DIR} ${STORE_DIR}
 chown -R vcap:vcap $RUN_DIR $LOG_DIR $CONFIG_DIR ${STORE_DIR}
 
-echo <%= p("credential.googlecredentials") %> | base64 -d > $CONFIG_DIR/google-credentials.json
+echo <%= esc(p("credential.googlecredentials")) %> | base64 -d > $CONFIG_DIR/google-credentials.json
 export GOOGLE_APPLICATION_CREDENTIALS=$CONFIG_DIR/google-credentials.json
-export MINIO_ACCESS_KEY="<%= p("credential.accesskey") %>"
-export MINIO_SECRET_KEY="<%= p("credential.secretkey") %>"
-export MINIO_PCF_TILE_VERSION=<%= p("pcf_tile_version") %>
+export MINIO_ACCESS_KEY=<%= esc(p("credential.accesskey")) %>
+export MINIO_SECRET_KEY=<%= esc(p("credential.secretkey")) %>
+export MINIO_PCF_TILE_VERSION=<%= esc(p("pcf_tile_version")) %>
 
 case $1 in
 
   start)
     echo $$ > $PIDFILE
-    exec ${BINPATH}/minio gateway --address ':<%= p("port") %>' gcs \
+    exec ${BINPATH}/minio gateway --address :<%= esc(p("port")) %> gcs \
          >> ${LOG_DIR}/minio-server.stdout.log \
          2>> ${LOG_DIR}/minio-server.stderr.log
     ;;

--- a/jobs/minio-gcs/templates/health_check.erb
+++ b/jobs/minio-gcs/templates/health_check.erb
@@ -13,7 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+<%
+  require "shellwords"
 
-http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= p("port") %>/minio/health/live)
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
+
+http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= esc(p("port")) %>/minio/health/live)
 
 [ "$http_response" = "200" ]

--- a/jobs/minio-nas/templates/ctl.erb
+++ b/jobs/minio-nas/templates/ctl.erb
@@ -1,9 +1,16 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 RUN_DIR=/var/vcap/sys/run/minio-nas
 LOG_DIR=/var/vcap/sys/log/minio-nas
-DATA_DIR='<%= p("data_dir") %>'
-CONFIG_DIR='<%= p("config_dir") %>'
+DATA_DIR=<%= esc(p("data_dir")) %>
+CONFIG_DIR=<%= esc(p("config_dir")) %>
 PIDFILE=${RUN_DIR}/pid
 BINPATH=/var/vcap/packages/minio
 
@@ -14,9 +21,9 @@ fi
 mkdir -p ${RUN_DIR} ${LOG_DIR}
 chown -R vcap:vcap $RUN_DIR $LOG_DIR
 
-export MINIO_ACCESS_KEY="<%= p("credential.accesskey") %>"
-export MINIO_SECRET_KEY="<%= p("credential.secretkey") %>"
-export MINIO_PCF_TILE_VERSION=<%= p("pcf_tile_version") %>
+export MINIO_ACCESS_KEY=<%= esc(p("credential.accesskey")) %>
+export MINIO_SECRET_KEY=<%= esc(p("credential.secretkey")) %>
+export MINIO_PCF_TILE_VERSION=<%= esc(p("pcf_tile_version")) %>
 
 case $1 in
 
@@ -36,7 +43,7 @@ case $1 in
     echo "NAS share mounted! Starting Minio." >> ${LOG_DIR}/minio-server.stdout.log
 
     echo $$ > $PIDFILE
-    exec ${BINPATH}/minio gateway -C $CONFIG_DIR --address ':<%= p("port") %>' nas $DATA_DIR \
+    exec ${BINPATH}/minio gateway -C $CONFIG_DIR --address :<%= esc(p("port")) %> nas $DATA_DIR \
          >> ${LOG_DIR}/minio-server.stdout.log \
          2>> ${LOG_DIR}/minio-server.stderr.log
     ;;

--- a/jobs/minio-nas/templates/health_check.erb
+++ b/jobs/minio-nas/templates/health_check.erb
@@ -13,7 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+<%
+  require "shellwords"
 
-http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= p("port") %>/minio/health/live)
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
+
+http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= esc(p("port")) %>/minio/health/live)
 
 [ "$http_response" = "200" ]

--- a/jobs/minio-server/templates/config.json.erb
+++ b/jobs/minio-server/templates/config.json.erb
@@ -1,10 +1,11 @@
+<% require 'json' -%>
 {
 	"version": "14",
 	"credential": {
-		"accessKey": "<%= p("credential.accesskey") %>",
-		"secretKey": "<%= p("credential.secretkey") %>"
+		"accessKey": <%= p('credential.accesskey').to_json %>,
+		"secretKey": <%= p('credential.secretkey').to_json %>
 	},
-	"region": "<%= p("region") %>",
+	"region": <%= p('region').to_json %>,
 	"browser": "on",
 	"logger": {
 		"console": {

--- a/jobs/minio-server/templates/ctl.erb
+++ b/jobs/minio-server/templates/ctl.erb
@@ -1,4 +1,11 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 RUN_DIR=/var/vcap/sys/run/minio-server
 LOG_DIR=/var/vcap/sys/log/minio-server
@@ -40,7 +47,7 @@ end.else do
   nodes = link('minio-server').instances.map { |instance| "#{protocol}://#{instance.address}${DATA_DIR}/" }
 end %>
 
-export MINIO_PCF_TILE_VERSION=<%= p("pcf_tile_version") %>
+export MINIO_PCF_TILE_VERSION=<%= esc(p("pcf_tile_version")) %>
 
 case $1 in
 
@@ -48,8 +55,8 @@ case $1 in
     echo $$ > $PIDFILE
 
     exec ${BINPATH}/minio server -C $CONFIG_DIR \
-         --address ':<%= p("port") %>' \
-         <% if link("minio-server").instances.length > 1 %><%= nodes.map{ |n| "\"#{n}\"" }.join(' ') %><% else %>${DATA_DIR}/<% end %> \
+         --address :<%= esc(p("port")) %> \
+         <% if link("minio-server").instances.length > 1 %><%= esc(nodes.map{ |n| "\"#{n}\"" }.join(' ')) %><% else %>${DATA_DIR}/<% end %> \
          >> ${LOG_DIR}/minio-server.stdout.log \
          2>> ${LOG_DIR}/minio-server.stderr.log
 

--- a/jobs/minio-server/templates/health_check.erb
+++ b/jobs/minio-server/templates/health_check.erb
@@ -13,7 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+<%
+  require "shellwords"
 
-http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= p("port") %>/minio/health/live)
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
+
+http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" http://localhost:<%= esc(p("port")) %>/minio/health/live)
 
 [ "$http_response" = "200" ]

--- a/jobs/smoke-tests/templates/run.erb
+++ b/jobs/smoke-tests/templates/run.erb
@@ -1,11 +1,19 @@
 #!/bin/bash
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+%>
 
 MC=/var/vcap/packages/mc/mc
 
-ACCESS_KEY="<%= link('minio').p('credential.accesskey') %>"
-SECRET_KEY="<%= link('minio').p('credential.secretkey') %>"
-PORT="<%= link('minio').p('port') %>"
-HOST="<%= link('minio').instances[0].address %>"
+ACCESS_KEY=<%= esc(link('minio').p('credential.accesskey')) %>
+SECRET_KEY=<%= esc(link('minio').p('credential.secretkey')) %>
+PORT=<%= esc(link('minio').p('port')) %>
+HOST=<%= esc(link('minio').instances[0].address) %>
+
 export MC_HOSTS_myminio=http://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
 
 # MakeBucket


### PR DESCRIPTION
Hi there,

This PR fixes classical escaping issues that can be found in many BOSH Releases.

Without this, an operator could accidentally break the JSON of BASH syntax, inject unindented config or scripts (that are run as root), which sometimes can lead to catastrophic consequences.

This is even more a concern when in a context of on-demand services, where BOSH deployments are operated by some service brokers, that possibly injects user-provided values in some machine-generated BOSH deployment manifests. There, malicious users could do horrible things with the deployed infrastructure.

That's why the best practice is to speculatively escape *everything* we can, which is the point here in this PR.

**Implementation notes:**
- We use `Shellwords.shellescape()`. The way it works is to add backslashes all over the place, which does the job. This explains why we remove any single `'` or double quotes `"` whenever we use the `esc()` function.
- We use the native `.to_json` Ruby method from the `json` package, which provides double quotes for strings. This explains why we don't need to specify those double quotes `"` in such case.

Best,
Benjamin