### PR TITLE
Revert "Check "live" endpoint in the monit script (#113)"

### DIFF
--- a/jobs/minio-server/monit
+++ b/jobs/minio-server/monit
@@ -1,16 +1,5 @@
-<% protocol = nil %>
-<% if_p('server_cert') do %>
-  <% protocol = 'https' %>
-<% end.else do %>
-  <% protocol = 'http' %>
-<% end %>
-
 check process minio-server
   with pidfile /var/vcap/sys/run/minio-server/pid
   start program "/var/vcap/jobs/minio-server/bin/ctl start"
   stop program "/var/vcap/jobs/minio-server/bin/ctl stop"
   group vcap
-  if failed host localhost port <%= p("port") %> protocol <%= "#{protocol}" %>
-      and request '/minio/health/live'
-      with timeout 60 seconds for 5 cycles
-  then restart


### PR DESCRIPTION
The commit had issues with monit and https endpoints for minio.

This reverts commit 5e354309bfaddf53804959be32f024fa493f68ed.