### PR TITLE
The file system type change: ext4 (default) to xfs

### DIFF
--- a/manifests/manifest-fs-example.yml
+++ b/manifests/manifest-fs-example.yml
@@ -54,6 +54,8 @@ instance_groups:
   - name: default
   vm_type: default
   persistent_disk_type: 2048
+  env:
+    persistent_disk_fs: xfs
   stemcell: default
 
 - name: bucket-seeding # To create default buckets after manifest-deploy


### PR DESCRIPTION
There is a problem if you want to store many small files.
For example, if you store a file in a directory `mydir/myfile.xml` inside a bucket `mybucket` MinIO creates:
- data file: `minio-server/mybucket/mydir/myfile.xml`
- meta file: `minio-server/.minio.sys/buckets/mybucket/mydir/myfile.xml/fs.json`
So, two objects `mydir`, `myfile.xml` are represented as five inodes.

BOSH supports two different persistent disk filesystem types: ext4 (default) and xfs - https://bosh.io/docs/persistent-disk-fs/
By default BOSH creates persistent disks with inode limits:
- ext4/100GB: `6_553_600`
- xfs/100GB: `52_427_776`

So, `xfs` seems to be a good default filesystem type.