### PR TITLE
Update smoke-test and mc errand run.erb template

### DIFF
--- a/jobs/mc/templates/run.erb
+++ b/jobs/mc/templates/run.erb
@@ -21,7 +21,7 @@ ACCESS_KEY="<%= link('minio').p('credential.accesskey') %>"
 SECRET_KEY="<%= link('minio').p('credential.secretkey') %>"
 PORT="<%= link('minio').p('port') %>"
 HOST="<%= link('minio').instances[0].address %>"
-export MC_HOSTS_myminio=http://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
+export MC_HOST_myminio=http://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
 
 bash <<EOF
 <%= p("script") %>

--- a/jobs/smoke-tests/templates/run.erb
+++ b/jobs/smoke-tests/templates/run.erb
@@ -21,7 +21,7 @@ ACCESS_KEY="<%= link('minio').p('credential.accesskey') %>"
 SECRET_KEY="<%= link('minio').p('credential.secretkey') %>"
 PORT="<%= link('minio').p('port') %>"
 HOST="<%= link('minio').instances[0].address %>"
-export MC_HOSTS_myminio=http://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
+export MC_HOST_myminio=http://$ACCESS_KEY:$SECRET_KEY@$HOST:$PORT
 
 # MakeBucket
 $MC mb myminio/test


### PR DESCRIPTION
With the latest `mc` client the environment variable to connect to minio is now MC_HOST_<alias>.

Fixes: #133 