### PR TITLE
Provide health script for BOSH DNS

### DIFF
--- a/jobs/minio-server/spec
+++ b/jobs/minio-server/spec
@@ -3,6 +3,7 @@ name: minio-server
 templates:
   ctl.erb: bin/ctl
   health_check.erb: bin/health_check
+  health_check.erb: bin/dns/healthy
   dns/aliases.json.erb: dns/aliases.json
   public.crt.erb: config/public.crt
   private.key.erb: config/private.key


### PR DESCRIPTION
BOSH DNS depends on job/bin/dns/healthy script for health check