### PR TITLE
Register console

### DIFF
--- a/jobs/minio-azure/spec
+++ b/jobs/minio-azure/spec
@@ -27,6 +27,9 @@ properties:
   port:
     description: "The port on which the Minio server should bind"
     default: 9000
+  console_port:
+    description: "The port on which the Minio Console UI should bind"
+    default: 9001
   pcf_tile_version:
     description: "PCF Tile version"
     default: ""

--- a/jobs/minio-azure/templates/ctl.erb
+++ b/jobs/minio-azure/templates/ctl.erb
@@ -33,7 +33,7 @@ case $1 in
 
   start)
     echo $$ > $PIDFILE
-    exec ${BINPATH}/minio gateway --address ':<%= p("port") %>' azure \
+    exec ${BINPATH}/minio gateway --address ':<%= p("port") %>' --console-address ':<%= p("console_port") %>'  azure \
          >> ${LOG_DIR}/minio-server.stdout.log \
          2>> ${LOG_DIR}/minio-server.stderr.log
     ;;

--- a/jobs/minio-gcs/spec
+++ b/jobs/minio-gcs/spec
@@ -33,6 +33,9 @@ properties:
   port:
     description: "The port on which the Minio server should bind"
     default: 9000
+  console_port:
+    description: "The port on which the Minio Console UI should bind"
+    default: 9001
   pcf_tile_version:
     description: "PCF Tile version"
     default: ""

--- a/jobs/minio-gcs/templates/ctl.erb
+++ b/jobs/minio-gcs/templates/ctl.erb
@@ -35,7 +35,7 @@ case $1 in
 
   start)
     echo $$ > $PIDFILE
-    exec ${BINPATH}/minio gateway --address ':<%= p("port") %>' gcs \
+    exec ${BINPATH}/minio gateway --address ':<%= p("port") %>' --console-address ':<%= p("console_port") %>'  gcs \
          >> ${LOG_DIR}/minio-server.stdout.log \
          2>> ${LOG_DIR}/minio-server.stderr.log
     ;;

--- a/manifests/ops/register-console.yml
+++ b/manifests/ops/register-console.yml
@@ -12,20 +12,6 @@
         routes:
           - name: minio_console
             port: 9001
-
-
-- type: replace
-  path: /instance_groups/name=minio/jobs/name=route_registrar?
-  value:
-    name: route_registrar
-    release: routing
-    consumes:
-      nats: {from: nats, deployment: cf}
-    properties:
-      route_registrar:
-        routes:
-          - name: minio_console
-            port: 9001
             registration_interval: 20s
             uris:
               - ((minio_console_uri))

--- a/manifests/ops/register-console.yml
+++ b/manifests/ops/register-console.yml
@@ -11,7 +11,7 @@
       route_registrar:
         routes:
           - name: minio_console
-            port: ((minio_console_port))
+            port: 9001
 
 
 - type: replace


### PR DESCRIPTION
- `console_port` support for Azure & GCS
- `ops/register-console.yml` fix